### PR TITLE
Fix: Readme example of AplDocument constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ class LaunchIntentHandler {
     const responseBuilder = handlerInput.responseBuilder;
     return responseBuilder
         .addDirective(
-        new AplDocument({
-            (<LaunchAplDocument />).getDirective();
-        }))
+        new AplDocument(
+            <LaunchAplDocument />
+        ).getDirective())
         .speak("Welcome to my first JSX for APL skill")
         .getResponse();
   }


### PR DESCRIPTION
I've tried to use it in my Skill that using TypeScript.
And I've got the following error.

## Error
### Code

```tsx
import React from 'react';
import { APL, MainTemplate, Container, Text, AplDocument } from 'ask-sdk-jsx-for-apl';

export class LaunchAplDocument extends React.Component {
    private readonly launchMessage = 'Welcome to my first JSX for APL skill!';
    render() {
        return (
            <APL theme="dark">
                <MainTemplate>
                    <Container
                        alignItems="center"
                        justifyContent="spaceAround">
                        <Text
                            text={this.launchMessage}
                            fontSize="50px"
                            color="rgb(251,184,41)" />
                    </Container>
                </MainTemplate>
            </APL>
        );
    }
}

const test = new AplDocument({
    (<LaunchAplDocument />).getDirective()
})
```

### stdout

```bash
$ tsc
src/LaunchRequest/LaunchRequest.apl.tsx:43:5 - error TS1136: Property assignment expected.

43     (<LaunchAplDocument />).getDirective()
       ~

src/LaunchRequest/LaunchRequest.apl.tsx:44:1 - error TS1005: ',' expected.

44 })
   ~

src/LaunchRequest/LaunchRequest.apl.tsx:44:2 - error TS1128: Declaration or statement expected.

44 })
    ~
```

## Solutions

I try to fix the error, then I got the following code.

```typescript
const test = new AplDocument(
    <LaunchAplDocument />
).getDirective()
```

I think the README.md example should be fix the style.

Thanks.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
