### PR TITLE
feat: Add JSX support for Apl Layouts.

### DIFF
--- a/lib/responses/apl/common/context.tsx
+++ b/lib/responses/apl/common/context.tsx
@@ -23,6 +23,14 @@ export interface ImportDefinition {
   source?: string;
 }
 
+export interface LayoutDefinition {
+  [key: string]: {
+    parameters?: any;
+    items?: any;
+    [key: string]: any;
+  }
+}
+
 export const ResponseBuilderCtx = React.createContext<ResponseBuilder | null>(null);
 
 export interface MainTemplateDefinition {
@@ -54,6 +62,7 @@ export const {
 
 interface APLRoot {
   imports: ImportDefinition[];
+  layouts: LayoutDefinition;
 }
 export const {
   Provider: APLProvider,

--- a/lib/responses/apl/root/AplLayout.tsx
+++ b/lib/responses/apl/root/AplLayout.tsx
@@ -1,0 +1,57 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import * as React from 'react';
+import omit from 'lodash/omit';
+import { BaseComponent } from '../common/BaseComponent';
+import {
+  APLComponentProvider,
+  APLConsumer,
+  APLContext
+} from '../common/context';
+
+export interface AplLayoutProps {
+  name: string;
+  [key: string]: unknown;
+}
+
+export const AplLayout = (props: React.PropsWithChildren<AplLayoutProps>) => {
+  const aplCtx: APLContext = {
+    items: [],
+  };
+  return (
+    <>
+      <APLComponentProvider value={aplCtx}>
+        {props.children}
+      </APLComponentProvider>
+      <APLConsumer>
+        {(parentCtx) => {
+          if (parentCtx) {
+            const parameters = Object.keys(omit(props, ['name', 'children']));
+            parentCtx.layouts[props.name] = parentCtx.layouts[props.name] || {};
+            parentCtx.layouts[props.name].parameters = parameters;
+            parentCtx.layouts[props.name] = Object.assign(
+              parentCtx.layouts[props.name],
+              aplCtx
+            );
+          }
+          return null;
+        }}
+      </APLConsumer>
+      <BaseComponent definition={{ type: props.name, ...omit(props, ['name', 'children']) }} />
+    </>
+  );
+};

--- a/lib/responses/apl/root/index.tsx
+++ b/lib/responses/apl/root/index.tsx
@@ -17,3 +17,4 @@
 export * from './Apl';
 export * from './AplImports';
 export * from './MainTemplate';
+export * from './AplLayout';

--- a/test/lib/apl-document/apl-document.tsx
+++ b/test/lib/apl-document/apl-document.tsx
@@ -19,6 +19,7 @@ import { AplDocument } from "../../../lib";
 import { specs as aplSpecs } from "../../specs/apl-specs";
 import { specs as alexaLayoutSpecs } from "../../specs/alexa-layouts-specs"
 import { specs as aplCommandSpecs } from "../../specs/apl-commands-specs"
+import { specs as aplCustomLayoutsSpecs } from "../../specs/apl-custom-layouts"
 
 const getter = (doc) => new AplDocument(doc).getDocument();
 describe('APLDocument', () => {
@@ -30,5 +31,8 @@ describe('APLDocument', () => {
   });
   describe('APL Commands Specs', () => {
     aplCommandSpecs.forEach(({name, spec}) => test(name, () => spec(getter)));
+  });
+  describe('APL Custom Layouts Specs', () => {
+    aplCustomLayoutsSpecs.forEach(({name, spec}) => test(name, () => spec(getter)));
   });
 });

--- a/test/specs/apl-custom-layouts.tsx
+++ b/test/specs/apl-custom-layouts.tsx
@@ -1,0 +1,120 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import * as React from 'react';
+import {
+  APL,
+  MainTemplate,
+  Container,
+  Text,
+  Image,
+  AplLayout,
+} from '../../lib';
+import { APLSpec } from './types';
+
+export const innerAplLayoutSpec: APLSpec = (getter) => {
+  const apl = (
+    <APL>
+      <MainTemplate>
+        <Container>
+          <Text />
+          <AplLayout name="testLayout">
+            <Container>
+              <Image source="http://1" />
+            </Container>
+          </AplLayout>
+        </Container>
+      </MainTemplate>
+    </APL>
+  );
+  const doc = getter(apl);
+  const testLayout = doc.layouts['testLayout'];
+  expect(testLayout.items[0].type).toBe('Container');
+  expect(testLayout.items[0].items[0].type).toBe('Image');
+  expect(testLayout.items[0].items[0].source).toBe('http://1');
+  expect(doc.mainTemplate.items[0].items[1].type).toBe('testLayout');
+};
+
+export const aplLayoutWithParameters: APLSpec = (getter) => {
+    const apl = (
+      <APL>
+        <MainTemplate>
+          <Container>
+            <Text /> 
+            <AplLayout name="testLayout" imageWidth="100vh">
+              <Image source="http://1" width="${imageWidth}" />
+            </AplLayout>
+          </Container>
+        </MainTemplate>
+      </APL>
+    );
+    const doc = getter(apl);
+    const testLayout = doc.layouts['testLayout'];
+    const testLayoutInner = doc.mainTemplate.items[0].items[1];
+    expect(testLayoutInner.type).toBe('testLayout');
+    expect(testLayoutInner.imageWidth).toBe('100vh');
+    expect(testLayout.items[0].type).toBe('Image');
+    expect(testLayout.items[0].source).toBe('http://1');
+    expect(testLayout.items[0].width).toBe('${imageWidth}');
+    expect(testLayout.parameters).toEqual(["imageWidth"]);
+}
+
+export const aplLayoutsWithExistingLayouts: APLSpec = (getter) => {
+    const existingLayout = {
+        existingLayout: {
+            parameters: ["testParam"],
+            item: {
+                type: "Text",
+                text: "${testParam}"
+            }
+        }
+    }
+    const apl = (
+        <APL layouts={ existingLayout }>
+          <MainTemplate>
+            <Container>
+              <Text /> 
+              <AplLayout name="testLayout" imageWidth="100vh">
+                <Image source="http://1" width="${imageWidth}" />
+              </AplLayout>
+            </Container>
+          </MainTemplate>
+        </APL>
+      );
+      const doc = getter(apl);
+      const testLayout = doc.layouts['testLayout'];
+      const existingOne = doc.layouts['existingLayout'];
+      expect(testLayout.items[0].type).toBe('Image');
+      expect(testLayout.parameters).toEqual(["imageWidth"]);
+      expect(existingOne.item.type).toBe('Text');
+      expect(existingOne.parameters).toEqual(["testParam"]);
+
+}
+
+export const specs = [
+  {
+    name: 'apl layouts',
+    spec: innerAplLayoutSpec,
+  },
+  {
+    name: 'apl layouts with parameters',
+    spec: aplLayoutWithParameters,
+  },
+  {
+      name: 'apl layouts with existing parameters',
+      spec: aplLayoutsWithExistingLayouts
+  }
+];


### PR DESCRIPTION
## Description of changes:

- Added new component `AplLayout` to define JSX layouts by using existing ask-sdk-jsx-for-apl components.

### Example Usage:
```
// LayoutExample.jsx
...
<AplLayout name="LayoutExample">
   <Container width="100vw" height="100vh" direction="column">
     <Text text="Example for Jsx Layout" fontSize="50px" color="rgb(251,184,41)" />
     <Image source="exampleUrl" />
   </Container>
</AplLayout>
```

```
// MainApl.jsx
...
<APL>
   <MainTemplate>
     <LayoutExample />
   </MainTemplate>
</AplLayout>
```